### PR TITLE
Add patient info route by ID

### DIFF
--- a/WebPhapp/backend/dummy_data/patients.json
+++ b/WebPhapp/backend/dummy_data/patients.json
@@ -3,37 +3,37 @@
         {
             "first": "jacob",
             "last": "krantz",
-            "patient_id": "01",
+            "patientID": "01",
             "dob": "10-05-1996"
         },
         {
             "first": "maxwell",
             "last": "dulin",
-            "patient_id": "02",
+            "patientID": "02",
             "dob": "10-06-1996"
         },
         {
             "first": "andrew",
             "last": "yang",
-            "patient_id": "03",
+            "patientID": "03",
             "dob": "10-07-1996"
         },
         {
             "first": "mehak",
             "last": "bharagava",
-            "patient_id": "04",
+            "patientID": "04",
             "dob": "10-08-1996"
         },
         {
             "first": "jeb",
             "last": "kilfoyle",
-            "patient_id": "05",
+            "patientID": "05",
             "dob": "10-09-1996"
         },
         {
             "first": "jacob",
             "last": "krantz",
-            "patient_id": "06",
+            "patientID": "06",
             "dob": "3-02-2004"
         }
     ]

--- a/WebPhapp/backend/server.js
+++ b/WebPhapp/backend/server.js
@@ -89,7 +89,15 @@ Examples:
 
 Returns:
     List of patients with all personal information:
-    [{"first":"jacob","last":"krantz","patient_id":"01","dob":"10-05-1996"}, { ... }]
+    [
+        {
+            "first":"jacob",
+            "last":"krantz",
+            "patientID":"01",
+            "dob":"10-05-1996"
+        },
+        ... 
+    ]
 
 Relevant Express Docs:
     https://expressjs.com/en/api.html#req.query
@@ -104,7 +112,10 @@ app.get('/api/v1/patients', (req,res) => {
 
     // Searching for substrings 
     var matchingPatients = all_patients.filter(function(elem) {
-        if( last === undefined ){
+        if( first === undefined && last === undefined ){
+            // if no query given, return all patients
+            return true;
+        } else if( last === undefined ){
             return (elem.first.includes(first.toLowerCase()));
         }
         else if( first === undefined ){
@@ -121,6 +132,50 @@ app.get('/api/v1/patients', (req,res) => {
     console.log(msg);
 
     res.json(matchingPatients);
+});
+
+/*
+About:
+    An api endpoint that returns the info about a patient given a specific
+    patient ID. Patient data temporarily includes date of birth, first and 
+    last name, and patient ID. 
+    TODO: restrict query to a single prescriber.
+Examples:
+    Directly in terminal:
+        >>> curl "http://localhost:5000/api/v1/patients/01"
+    To be used in Axois call:
+        .get("/api/v1/patients/01")
+Returns:
+    Patient info object with all personal information:
+    {
+        "first":"jacob",
+        "last":"krantz",
+        "patientID":"01",
+        "dob":"10-05-1996"
+    }
+*/
+app.get('/api/v1/patients/:patientID', (req,res) => {
+    var patientID = req.params.patientID;
+
+    // will be replaced with DB call once we determine user auth.
+    var all_patients = readJsonFileSync(
+        __dirname + '/' + "dummy_data/patients.json").patients;
+
+    var matchingPatient = all_patients.find(function(patient){
+        return patient.patientID === patientID;
+    })
+
+    // log the backend process to the terminal
+    var msg = '/api/v1/patients/:patientID: ';
+    if(matchingPatient === undefined){
+        msg += 'Returning no patient. No patientID matching \'' + patientID.toString() + '\'';
+        matchingPatient = {};
+    } else {
+        msg += 'Returning patient info for patientID \'' + patientID.toString() + '\'';
+    }
+
+    console.log(msg);
+    res.json(matchingPatient);
 });
 
 // get the index

--- a/WebPhapp/backend/spec.js
+++ b/WebPhapp/backend/spec.js
@@ -91,7 +91,7 @@ describe("loading express", function() {
       .get("/api/v1/patients?first=jacob&last=krantz")
       .expect(function(res) {
         if(res.body.length <= 1) throw new Error('Should be two or more jacob krantz patients for testing.');
-        if([res.body[0].first, res.body[0].last, res.body[0].dob, res.body[0].patient_id].includes(undefined)){
+        if([res.body[0].first, res.body[0].last, res.body[0].dob, res.body[0].patientID].includes(undefined)){
           throw new Error('Found empty patient field.');
         }
         return true;
@@ -116,7 +116,7 @@ describe("loading express", function() {
       .get("/api/v1/patients?first=jacob")
       .expect(function(res) {
         if(res.body.length <= 1) throw new Error('Should be two or more jacob patients for testing.');
-        if([res.body[0].first, res.body[0].last, res.body[0].dob, res.body[0].patient_id].includes(undefined)){
+        if([res.body[0].first, res.body[0].last, res.body[0].dob, res.body[0].patientID].includes(undefined)){
           throw new Error('Found empty patient field.');
         }
         return true;
@@ -125,18 +125,83 @@ describe("loading express", function() {
   });
 
   it("test-route-patients-last", function(done) {
-    // test for fully qualified first and last name
+    // test for fully qualified last name
     request(server)
       .get("/api/v1/patients?last=krantz")
       .expect(function(res) {
         if(res.body.length <= 1) throw new Error('Should be two or more krantz patients for testing.');
-        if([res.body[0].first, res.body[0].last, res.body[0].dob, res.body[0].patient_id].includes(undefined)){
+        if([res.body[0].first, res.body[0].last, res.body[0].dob, res.body[0].patientID].includes(undefined)){
           throw new Error('Found empty patient field.');
         }
         return true;
       })
       .end(done);
   });
+
+  it("test-route-patients-null", function(done) {
+    // test to ensure all patients are returned when no queries are provided.
+    request(server)
+      .get("/api/v1/patients")
+      .expect(function(res) {
+        if(res.body.length <= 5) throw new Error('Should return all patients.');
+        return true;
+      })
+      .end(done);
+  });
+
+
+  // ------------------------------------------------------
+  //             Tests: /api/vi/patients
+  // ------------------------------------------------------
+
+
+  it("test-route-patients-id", function(done) {
+    // test for patientID that exists
+    request(server)
+      .get("/api/v1/patients/02")
+      .expect(function(res) {
+        if([res.body.first, res.body.last, res.body.dob, res.body.patientID].includes(undefined)){
+          throw new Error('Found empty patient field.');
+        }
+        return true;
+      })
+      .end(done);
+  });
+
+  it("test-route-patients-id-bad", function(done) {
+    // test for fully qualified first and last name
+    request(server)
+      .get("/api/v1/patients/0023456543456543234567")
+      .expect(function(res) {
+        var fields = new Set([res.body.first, res.body.last, res.body.dob, res.body.patientID]);
+        if(fields.length > 1){
+          throw new Error('Should not have any patient fields for bad patientID.');
+        }
+        if(!fields.has(undefined)){
+          throw new Error('Patient fields should be empty for bad patientID');
+        }
+        return true;
+      })
+      .end(done);
+  });
+
+  it("test-route-patients-id-bad2", function(done) {
+    // test for a patientID input that is of the wrong type
+    request(server)
+      .get("/api/v1/patients/astring")
+      .expect(function(res) {
+        var fields = new Set([res.body.first, res.body.last, res.body.dob, res.body.patientID]);
+        if(fields.length > 1){
+          throw new Error('Should not have any patient fields for bad patientID.');
+        }
+        if(!fields.has(undefined)){
+          throw new Error('Patient fields should be empty for bad patientID');
+        }
+        return true;
+      })
+      .end(done);
+  });
+
 
   // ------------------------------------------------------
   //             Tests: other

--- a/WebPhapp/client/src/App/components/People.js
+++ b/WebPhapp/client/src/App/components/People.js
@@ -7,23 +7,23 @@ class People extends Component {
   displayPeople = () => {
     return this.props.patientList.map(person => {
       return(
-        <tr key={person.patient_id}>
+        <tr key={person.patientID}>
           <td>
-          <a href = {"/patient?ID=" + person.patient_id}>
-          {person.patient_id}</a>
+          <a href = {"/patient?ID=" + person.patientID}>
+          {person.patientID}</a>
           </td>
           <td>
-            <a href = {"/patient?ID=" + person.patient_id} target="_blank">
+            <a href = {"/patient?ID=" + person.patientID} target="_blank">
               {person.first}
             </a>
           </td>
           <td>
-            <a href = {"/patient?ID=" + person.patient_id}>
+            <a href = {"/patient?ID=" + person.patientID}>
               {person.last}
             </a>
           </td>
           <td>
-            <a href = {"/patient?ID=" + person.patient_id}>
+            <a href = {"/patient?ID=" + person.patientID}>
               {person.dob}
             </a>
           </td>
@@ -55,7 +55,7 @@ class People extends Component {
 People.propTypes = {
   patientList: PropTypes.arrayOf(
       PropTypes.shape({
-        patient_id: PropTypes.number.isRequired,
+        patientID: PropTypes.number.isRequired,
         first: PropTypes.string,
         last: PropTypes.string,
         dob: PropTypes.string


### PR DESCRIPTION
- Adds route for getting a patient object given a `patientID`
- adds unit tests for the new route
- Fixes `/api/v1/patients` route to return all patients when no queries are given (previously: error)
- Naming change for consistency: `patient_id` -> `patientID`

@andrewjyang I made minor changes to `/client/src/App/components/People.js` that may have a conflict with PR #11. Easy fix if so, we would just need to see which PR gets merged first.