### PR TITLE
Blockchain prescriptions by patient ID

### DIFF
--- a/WebPhapp/PharmaChain/block_helper.js
+++ b/WebPhapp/PharmaChain/block_helper.js
@@ -129,7 +129,8 @@ async function read(index_value){
 }
 
 
-/*  This function takes a type and a value, and returns prescriptions
+/*  DEPRECATED: this function has been moved to WebPhapp/backend/block_helper.js
+    This function takes a type and a value, and returns prescriptions
     that have a type, of the first index and, a value of the second index.
     
 

--- a/WebPhapp/backend/block_helper.js
+++ b/WebPhapp/backend/block_helper.js
@@ -4,6 +4,23 @@ let fs = require("fs");
 let Web3 = require("web3");
 let net = require("net");
 
+//Converts a blockchain values object to a prescription
+var valuesToPrescription = function(values, prescriptionID) {
+    return {
+        prescriptionID: prescriptionID,
+        patientID:      parseInt(values['0']),
+        prescriberID:   parseInt(values['1']),
+        dispenserID:    parseInt(values['2']),
+        drugID:         parseInt(values['3']),
+        quantity:                values['4'],
+        fillDates:               values['5'].map(date => parseInt(date)),
+        writtenDate:    parseInt(values['6']),
+        daysFor:        parseInt(values['7']),
+        refillsLeft:    parseInt(values['8']),
+        cancelDate:     parseInt(values['10'])
+    };
+};
+
 module.exports = {
 
     /*
@@ -40,17 +57,7 @@ module.exports = {
         let prescription = {};
         try {
             let values = await Patient.methods.getPrescription(index_value).call({from: account});
-            prescription.prescriptionID = index_value;
-            prescription.patientID      = parseInt(values['0']);
-            prescription.prescriberID   = parseInt(values['1']);
-            prescription.dispenserID    = parseInt(values['2']);
-            prescription.drugID         = parseInt(values['3']);
-            prescription.quantity       = values['4'];
-            prescription.fillDates      = values['5'].map(date => parseInt(date));
-            prescription.writtenDate    = parseInt(values['6']);
-            prescription.daysFor        = parseInt(values['7']);
-            prescription.refillsLeft    = parseInt(values['8']);
-            prescription.cancelDate     = parseInt(values['10']);
+            prescription = valuesToPrescription(values, index_value);
         }
         catch(err) {
             error = err;
@@ -59,6 +66,77 @@ module.exports = {
         return new Promise((resolve, reject) => {
             if(error) reject(error);
             resolve({prescription});
+        });
+    },
+
+    /*
+    This function takes a field index and a value, and returns prescriptions
+    that have the give value at the field index.
+    Args:
+        field_i (int): 
+                0:patientID,
+                1:prescriberID,
+                2:dispenserID,
+                3:drugID,
+                4:drugQuantity,
+                5:dateWritten,
+                6:daysValid,
+                7:refillsLeft,
+                8:isCancelled,
+                9:cancelDate
+    Returns:
+        list of prescriptions that satisfy the query
+    Example:
+        read_by_value(0, 0)
+            This example will search for prescriptions with patientID = 0.
+            It will return all found prescriptions that match this criteria.
+    */
+    read_by_value: async function(field_i, value_i) {
+
+        let web3 = new Web3(
+            new Web3.providers.HttpProvider("http://10.50.0.2:22000", net)
+        );
+
+        
+        // get account information
+        let account = await web3.eth.personal.getAccounts();
+        account = account[0];
+
+        // Sets up contract requirements.
+        let source = fs.readFileSync('../PharmaChain/build/contracts/Patient.json'); 
+        let contracts = JSON.parse(source);
+        let Patient = new web3.eth.Contract(
+            contracts.abi,
+            null,
+            {data: contracts.bytecode}
+        );
+
+        Patient.options.address = fs.readFileSync(
+            "../PharmaChain/patient_contract_address.txt"
+        ).toString('ascii');
+        
+        var prescriptions = [];
+        var error;
+        try {
+            // check that field input is valid
+            if(field_i > 9 || field_i < 0) {
+                throw new Error("'field_i' is an index and must be within 0-9.");
+            }
+
+            for(i = 0; i < await Patient.methods.getDrugChainLength().call({from: account}); i++){
+                let values = await Patient.methods.getPrescription(i).call({from: account});
+                if(values[field_i] == value_i) {
+                    prescriptions.push(valuesToPrescription(values, i));
+                }
+            }
+        }
+        catch(err) {
+            error = err;
+        }
+
+        return new Promise((resolve, reject) => {
+            if(error) reject(error);
+            resolve({prescriptions});
         });
     }
 }

--- a/WebPhapp/backend/block_helper.js
+++ b/WebPhapp/backend/block_helper.js
@@ -24,9 +24,9 @@ var valuesToPrescription = function(values, prescriptionID) {
 module.exports = {
 
     /*
-    This function takes an index and returns a prescription from the drugChain.
+    This function takes an index and returns a prescription from the blockchain.
     Args:
-        index: (int), idnex of prescription on the blockchain
+        index: (int), index of prescription on the blockchain
     Returns:
         { prescription }
     */

--- a/WebPhapp/backend/mysql_helper.js
+++ b/WebPhapp/backend/mysql_helper.js
@@ -25,11 +25,12 @@ module.exports = {
         var q = `
         SELECT ID, NAME
         FROM seniordesign1.pharmacopeia
-        WHERE ID IN (?)
+        WHERE ID IN ( ? )
         `;
 
         return new Promise((resolve, reject) => {
-            connection.query(q,[drugIDs.toString()], (error, rows, fields) => {
+            var values = [drugIDs.map(id => id.toString())];
+            connection.query(q, values, (error, rows, fields) => {
                 if (error) reject(error);
                 resolve({rows, fields});
             });

--- a/WebPhapp/backend/server.js
+++ b/WebPhapp/backend/server.js
@@ -179,8 +179,13 @@ app.get('/api/v1/prescriptions/:patientID', (req,res) => {
                 });
 
                 // Could be undefined on return
-                if(drug.length !== 0)
-                prescriptions[i].drugName = drug[0].NAME;
+                if(drug.length !== 0) {
+                    prescriptions[i].drugName = drug[0].NAME;
+                }
+                else {
+                    prescriptions[i].drugName = "drugName";
+                }
+                
             }
 
             console.log(msg);
@@ -284,7 +289,7 @@ app.get('/api/v1/prescriptions/single/:prescriptionID', (req,res) => {
             handlePrescriptionCallback(answer.prescription);
         }).catch((error) => {
             console.log('error: ', error);
-            res.status(400).send('Prescription not found.');
+            res.status(400).send('Error searching for prescription by prescriptionID.');
         });
     }
     else { // load prescription from dummy data

--- a/WebPhapp/backend/server.js
+++ b/WebPhapp/backend/server.js
@@ -30,6 +30,18 @@ function readJsonFileSync(filepath, encoding){
     return JSON.parse(file);
 }
 
+/*
+    given a prescription, replaces all date integers with strings.
+    Returns updated prescription.
+    Assumes that all fields are properly filled.
+*/
+function convertDatesToString(prescription){
+    prescription.writtenDate = new Date(prescription.writtenDate).toString();
+    prescription.fillDates = prescription.fillDates.filter(dateInt => dateInt > 0);
+    prescription.fillDates = prescription.fillDates.map(dateInt => new Date(dateInt).toString());
+    return prescription;
+}
+
 // Serve the static files from the React app
 app.use(express.static(path.join(__dirname, '../client/build')));
 
@@ -129,56 +141,77 @@ Returns:
 */
 app.get('/api/v1/prescriptions/:patientID', (req,res) => {
     var patientID = parseInt(req.params.patientID);
-    var prescriptions = readJsonFileSync(
-        __dirname + '/' + "dummy_data/prescriptions.json").prescriptions;
+    var handlePrescriptionsCallback = function(prescriptions) {
+        var msg = 'Sent ' + prescriptions.length.toString() +
+                    ' prescription(s) for patient ID ' + patientID.toString();
 
-    var toSend = [];
-    prescriptions.forEach(prescription => {
-        if (prescription.patientID === patientID) toSend.push(prescription);
-    });
-
-    // if no prescriptions for a patient ID, return early
-    var msg = 'Sent ' + toSend.length.toString() +
-                ' prescription(s) for patient ID ' + patientID.toString();
-    if (toSend.length === 0) {
-        console.log(msg);
-        res.json([]);
-        return;
-    }
-
-    // if no connection string (Travis testing), fill drugName with dummy info
-    if (!conn.MySQL) {
-        for (var i = 0; i < toSend.length; i++){
-            toSend[i].drugName = "drugName";
-        }
-        res.json(toSend);
-        return;
-    }
-
-    // Look up the drug names given the list of drugIDs in MySQL
-    var drugIDs = toSend.map((prescription) => {
-        return prescription.drugID;
-    })
-
-    mysql.getDrugNamesFromIDs(drugIDs, connection)
-    .then((answer) => {
-        for (var i = 0; i < toSend.length; i++){
-            var drug = answer.rows.filter((row) => {
-                return (row.ID === toSend[i].drugID);
-            });
-
-            // Could be undefined on return
-            if(drug.length !== 0)
-              toSend[i].drugName = drug[0].NAME;
+        // if no prescriptions for a patient ID, return early
+        if (prescriptions.length === 0) {
+            console.log(msg);
+            res.json([]);
+            return;
         }
 
-        console.log(msg);
-        res.json(toSend);
-    })
-    .catch((error) => {
-        console.log("/api/v1/prescriptions: error: ", error);
-        res.json({});
-    });
+        // Convert date integers to strings
+        prescriptions = prescriptions.map(
+            prescription => convertDatesToString(prescription)
+        );
+
+        // if no connection string (Travis testing), fill drugName with dummy info
+        if (!conn.MySQL) {
+            for (var i = 0; i < prescriptions.length; i++){
+                prescriptions[i].drugName = "drugName";
+            }
+            res.json(prescriptions);
+            return;
+        }
+
+        // Look up the drug names given the list of drugIDs in MySQL
+        var drugIDs = prescriptions.map((prescription) => {
+            return prescription.drugID;
+        })
+
+        mysql.getDrugNamesFromIDs(drugIDs, connection)
+        .then((answer) => {
+            for (var i = 0; i < prescriptions.length; i++){
+                var drug = answer.rows.filter((row) => {
+                    return (row.ID === prescriptions[i].drugID);
+                });
+
+                // Could be undefined on return
+                if(drug.length !== 0)
+                prescriptions[i].drugName = drug[0].NAME;
+            }
+
+            console.log(msg);
+            res.json(prescriptions);
+        })
+        .catch((error) => {
+            console.log("/api/v1/prescriptions: error: ", error);
+            res.status(400).send({});
+        });
+    };
+
+    if(conn.Blockchain){
+        var field_patientID = 0;
+        block_helper.read_by_value(field_patientID, patientID)
+        .then((answer) => {
+            handlePrescriptionsCallback(answer.prescriptions);
+        }).catch((error) => {
+            console.log('error: ', error);
+            res.status(400).send('Error in searching blockchain for prescriptions matching patientID.');
+        });
+    }
+    else { // search prescriptions from dummy data
+        var prescriptions = readJsonFileSync(
+            __dirname + '/' + "dummy_data/prescriptions.json").prescriptions;
+    
+        var toSend = [];
+        prescriptions.forEach(prescription => {
+            if (prescription.patientID === patientID) toSend.push(prescription);
+        });
+        handlePrescriptionsCallback(toSend);
+    }
 });
 
 /*
@@ -215,6 +248,9 @@ app.get('/api/v1/prescriptions/single/:prescriptionID', (req,res) => {
             res.status(400).send({});
             return;
         }
+
+        // Convert date integers to strings
+        prescription = convertDatesToString(prescription);
 
         // if no connection string (Travis testing), fill drugName with dummy info
         if (!conn.MySQL) {


### PR DESCRIPTION
- Update backend route `/api/v1/prescriptions/:patientID` to read prescriptions off the blockchain. This route returns all prescriptions associated with a given `patientID`
- Convert date integers to strings for front end handling
- Fix MySQL pharmacopoeia bug where only the first row of drug names is returned. This was a prepared statement issue.
- Address code review from #33 