### PR TITLE
Cancel edit branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,3 +121,10 @@ cd WebPhapp/
 sudo rm -r quorum-maker
 git clone https://github.com/Pharmachain/quorum-maker
 ```
+
+- If you see the following backend error:
+```
+error: TypeError: values.5.map is not a function
+```
+make sure you are running your backend with npm run start
+not npm start.

--- a/WebPhapp/PharmaChain/block_helper.js
+++ b/WebPhapp/PharmaChain/block_helper.js
@@ -221,7 +221,8 @@ async function update( drugChainIndex, dispenserID,drugQuantity, fulfillmentDate
 
 }
 
-//Returns the number of prescriptions stored on the blockchain.
+// DEPRECATED: this function has been moved to WebPhapp/backend/block_helper.js
+// Returns the number of prescriptions stored on the blockchain.
 async function getChainLength(){
 
     // Connecting to the node 1. Will want to change to IPC connection eventually. 

--- a/WebPhapp/PharmaChain/cancel_prescription.js
+++ b/WebPhapp/PharmaChain/cancel_prescription.js
@@ -2,13 +2,15 @@ let fs = require("fs");
 let Web3 = require("web3");
 let net = require("net");
 
-/*  This function cancels an existing prescription on the drugChain
+/*  This function cancels an existing prescription on the blockchain
     User input: prescription arguments
-    Argument list: drugChainIndex, date
-    Example usage: node cancel_prescription.js 0 10
+    Args:
+        chainIndex (int)
+        date (int)
+    Example: 
+        sudo node cancel_prescription.js 0 10
 */
-
-async function cancel( drugChainIndex, date){
+async function cancel( chainIndex, date){
 
     // Connecting to the node 1. Will want to change to IPC connection eventually. 
 	let web3 = new Web3( new Web3.providers.HttpProvider("http://10.50.0.2:22000", net));
@@ -28,7 +30,7 @@ async function cancel( drugChainIndex, date){
 
     // Set up prescription data to be sent.
     Patient.options.address = fs.readFileSync("./patient_contract_address.txt").toString('ascii');
-    let transaction = await Patient.methods.cancelPrescription(drugChainIndex, date);
+    let transaction = await Patient.methods.cancelPrescription(chainIndex, date);
     
     // Submitting prescription transaction.
     let encoded_transaction = transaction.encodeABI();
@@ -45,9 +47,8 @@ async function cancel( drugChainIndex, date){
 }
 
 // Main: 
-
 let args = process.argv
-let drugChainIndex= args[2];
+let chainIndex= args[2];
 let date = args[3];
 
-cancel(drugChainIndex, date);
+cancel(chainIndex, date);

--- a/WebPhapp/PharmaChain/cancel_prescription.js
+++ b/WebPhapp/PharmaChain/cancel_prescription.js
@@ -2,13 +2,13 @@ let fs = require("fs");
 let Web3 = require("web3");
 let net = require("net");
 
-/*  This function updates an existing prescription on the drugChain
+/*  This function cancels an existing prescription on the drugChain
     User input: prescription arguments
-    Argument list: drugChainIndex, dispenserID, drugQuantity, daysValid, refillsLeft
-    Example usage: node update_prescription.js 0 1 2 4 8
+    Argument list: drugChainIndex, date
+    Example usage: node cancel_prescription.js 0 10
 */
 
-async function update( drugChainIndex, dispenserID, drugQuantity, daysValid, refillsLeft){
+async function cancel( drugChainIndex, date){
 
     // Connecting to the node 1. Will want to change to IPC connection eventually. 
 	let web3 = new Web3( new Web3.providers.HttpProvider("http://10.50.0.2:22000", net));
@@ -28,7 +28,7 @@ async function update( drugChainIndex, dispenserID, drugQuantity, daysValid, ref
 
     // Set up prescription data to be sent.
     Patient.options.address = fs.readFileSync("./patient_contract_address.txt").toString('ascii');
-    let transaction = await Patient.methods.updatePrescription(drugChainIndex, dispenserID, drugQuantity, daysValid, refillsLeft);
+    let transaction = await Patient.methods.cancelPrescription(drugChainIndex, date);
     
     // Submitting prescription transaction.
     let encoded_transaction = transaction.encodeABI();
@@ -48,9 +48,6 @@ async function update( drugChainIndex, dispenserID, drugQuantity, daysValid, ref
 
 let args = process.argv
 let drugChainIndex= args[2];
-let dispenserID = args[3];
-let drugQuantity = args[4]; 
-let daysValid = args[5];
-let refillsLeft = args[6];
+let date = args[3];
 
-update(drugChainIndex, dispenserID, drugQuantity, daysValid, refillsLeft);
+cancel(drugChainIndex, date);

--- a/WebPhapp/PharmaChain/contracts/PrescriptionData.sol
+++ b/WebPhapp/PharmaChain/contracts/PrescriptionData.sol
@@ -7,7 +7,20 @@ contract PrescriptionData is PrescriptionBase {
 
     Prescription[] public drugChain;
 
-    function getPrescription(uint chainIndex) public view returns (uint256, uint128, uint128, uint64, string, uint64[16], uint64, uint16, uint8, bool, uint64) {
+    function getPrescription(uint chainIndex)
+        public view returns (
+            uint256,
+            uint128,
+            uint128,
+            uint64,
+            string memory,
+            uint64[16] memory,
+            uint64,
+            uint16,
+            uint8,
+            bool,
+            uint64) {
+        
         Prescription memory p = drugChain[chainIndex];
         return (
             p.patientID,
@@ -36,9 +49,14 @@ contract PrescriptionData is PrescriptionBase {
         return 1;
     }
 
-    function updatePrescription(uint chainIndex, uint128 dispenserID, string drugQuantity, 
-                                uint16 daysValid, uint8 refillsLeft) public returns(uint) {
-    	Prescription storage p = drugChain[chainIndex];
+    function updatePrescription(
+        uint chainIndex,
+        uint128 dispenserID,
+        string memory drugQuantity,
+        uint16 daysValid,
+        uint8 refillsLeft) public returns(uint) {
+    	
+        Prescription storage p = drugChain[chainIndex];
         if(p.isCancelled == true){
             //Prescription cancelled, cannot edit, error
             return 1;
@@ -51,9 +69,19 @@ contract PrescriptionData is PrescriptionBase {
         return 0;
     }
 
-    function addPrescription(uint256 patientID, uint128 prescriberID, uint128 dispenserID, uint64 drugID, string memory drugQuantity,
-                             uint64[16] memory fulfillmentDates, uint64 dateWritten, uint16 daysValid,
-                             uint8 refillsLeft, bool isCancelled, uint64 cancelDate) public returns (uint) {
+    function addPrescription(
+        uint256 patientID,
+        uint128 prescriberID,
+        uint128 dispenserID,
+        uint64 drugID,
+        string memory drugQuantity,
+        uint64[16] memory fulfillmentDates,
+        uint64 dateWritten,
+        uint16 daysValid,
+        uint8 refillsLeft,
+        bool isCancelled,
+        uint64 cancelDate) public returns (uint) {
+            
         Prescription memory p = Prescription(
             patientID,
             prescriberID,
@@ -69,12 +97,12 @@ contract PrescriptionData is PrescriptionBase {
         );
 
         drugChain.push(p);
-        return drugChain.length -1;
+        return drugChain.length - 1;
     }
 
     function cancelPrescription(uint chainIndex, uint64 date) public returns (uint) {
     	// Prescription storage p = drugChain[chainIndex];
-    	if(drugChain[chainIndex].isCancelled) {
+        if(drugChain[chainIndex].isCancelled) {
 		    // Prescription already cancelled, error
             return 1;
         }
@@ -90,7 +118,7 @@ contract PrescriptionData is PrescriptionBase {
             //cannot refill cancelled prescription
             return 1;
         }
-        if (p.refillsLeft == 0) {
+        if (p.refillsLeft < 1) {
             //cannot refill empty prescription
             return 2;
         }
@@ -102,6 +130,6 @@ contract PrescriptionData is PrescriptionBase {
                 //NOTE we need to discuss what happens if initial refillsLeft > 16
             }
         }
-	return 0;
+        return 0;
     }     
 }

--- a/WebPhapp/PharmaChain/contracts/PrescriptionData.sol
+++ b/WebPhapp/PharmaChain/contracts/PrescriptionData.sol
@@ -28,19 +28,19 @@ contract PrescriptionData is PrescriptionBase {
 
     function updatePrescription(uint chainIndex, uint128 dispenserID, string drugQuantity, 
             uint16 daysValid,uint8 refillsLeft) public returns(uint) {
-	Prescription storage p = drugChain[chainIndex];
-	if(p.isCancelled == true){
-	    //Prescription cancelled, cannot edit, error
-	    return 1;
+    	Prescription storage p = drugChain[chainIndex];
+        if(p.isCancelled == true){
+            //Prescription cancelled, cannot edit, error
+            return 1;
         }
         p.dispenserID = dispenserID;
         p.drugQuantity = drugQuantity;
         p.daysValid = daysValid;
-	p.refillsLeft = refillsLeft;
+        p.refillsLeft = refillsLeft;
 
         return 0;
-
     }
+
     function addPrescription(
         uint256 patientID,
         uint128 prescriberID,
@@ -60,16 +60,16 @@ contract PrescriptionData is PrescriptionBase {
         return drugChain.length -1;
     }
 
-    function cancellPrescription(uint chainIndex, uint64 date) public returns (uint){
-    	Prescription storage p = drugChain[chainIndex];
-    	if(p.isCancelled){
-		//Prescription already cancelled, error
+    function cancelPrescription(uint chainIndex, uint64 date) public returns (uint){
+    	// Prescription storage p = drugChain[chainIndex];
+    	if(drugChain[chainIndex].isCancelled){
+		// Prescription already cancelled, error
             return 1;
-	} else {
-	    p.cancelDate = date;
-            p.isCancelled = true;
-	}
-	return 0;
+        }
+        
+        drugChain[chainIndex].cancelDate = date;
+        drugChain[chainIndex].isCancelled = true;
+        return 0;
     }
 
     function redeemPrescription(uint chainIndex, uint64 date) public returns (uint){

--- a/WebPhapp/PharmaChain/contracts/PrescriptionData.sol
+++ b/WebPhapp/PharmaChain/contracts/PrescriptionData.sol
@@ -26,19 +26,16 @@ contract PrescriptionData is PrescriptionBase {
         return 1;
     }
 
-    function updatePrescription(uint chainIndex, uint128 dispenserID,string drugQuantity, uint64[16] fulfillmentDates, 
-            uint16 daysValid, bool isCancelled, uint64 cancelDate) public returns(uint) {
+    function updatePrescription(uint chainIndex, uint128 dispenserID, string drugQuantity, 
+            uint16 daysValid) public returns(uint) {
 	Prescription storage p = drugChain[chainIndex];
-	if(p.isCancelled = true){
+	if(p.isCancelled == true){
 	    //Prescription cancelled, cannot edit, error
 	    return 1;
         }
         p.dispenserID = dispenserID;
         p.drugQuantity = drugQuantity;
-        p.fulfillmentDates = fulfillmentDates;
         p.daysValid = daysValid;
-        p.isCancelled = isCancelled;
-        p.cancelDate = cancelDate;
 
         return 0;
 

--- a/WebPhapp/PharmaChain/contracts/PrescriptionData.sol
+++ b/WebPhapp/PharmaChain/contracts/PrescriptionData.sol
@@ -20,18 +20,21 @@ contract PrescriptionData is PrescriptionBase {
     
     function updatePrescription(uint chainIndex, uint128 dispenserID,string drugQuantity, uint64[16] fulfillmentDates, 
             uint16 daysValid, bool isCancelled, uint64 cancelDate) public returns(uint) {
-        Prescription updated_p = drugChain[chainIndex];
-        updated_p.dispenserID = dispenserID;
-        updated_p.drugQuantity = drugQuantity;
-        updated_p.fulfillmentDates = fulfillmentDates;
-        updated_p.daysValid = daysValid;
-        updated_p.isCancelled = isCancelled;
-        updated_p.cancelDate = cancelDate;
+		if(drugChain[chainIndex].isCancelled = true){
+			//Prescription cancelled, cannot edit, error
+			return 1;
+		}
+        drugChain[chainIndex].dispenserID = dispenserID;
+        drugChain[chainIndex].drugQuantity = drugQuantity;
+        drugChain[chainIndex].fulfillmentDates = fulfillmentDates;
+        drugChain[chainIndex].daysValid = daysValid;
+        drugChain[chainIndex].isCancelled = isCancelled;
+        drugChain[chainIndex].cancelDate = cancelDate;
 
         return 0;
 
     }
-     function addPrescription(
+	function addPrescription(
         uint256 patientID,
         uint128 prescriberID,
         uint128 dispenserID,
@@ -49,4 +52,20 @@ contract PrescriptionData is PrescriptionBase {
         drugChain.push(p);
         return drugChain.length -1;
     }
+	function cancelPrescription(uint chainIndex) public returns (uint){
+		Prescription storage p = drugChain[chainIndex];
+		if(p.isCancelled){
+			//Prescription already cancelled, error
+			return 1;
+		} else {
+			drugChain[chainIndex].isCancelled = true;
+		}
+		return 0;
+	}
+	/*
+	function redeemPrescription(chainIndex, date) public returns (uint){
+		Prescription 
+
+	}
+	*/
 }

--- a/WebPhapp/PharmaChain/contracts/PrescriptionData.sol
+++ b/WebPhapp/PharmaChain/contracts/PrescriptionData.sol
@@ -27,7 +27,7 @@ contract PrescriptionData is PrescriptionBase {
     }
 
     function updatePrescription(uint chainIndex, uint128 dispenserID, string drugQuantity, 
-            uint16 daysValid) public returns(uint) {
+            uint16 daysValid,uint8 refillsLeft) public returns(uint) {
 	Prescription storage p = drugChain[chainIndex];
 	if(p.isCancelled == true){
 	    //Prescription cancelled, cannot edit, error
@@ -36,6 +36,7 @@ contract PrescriptionData is PrescriptionBase {
         p.dispenserID = dispenserID;
         p.drugQuantity = drugQuantity;
         p.daysValid = daysValid;
+	p.refillsLeft = refillsLeft;
 
         return 0;
 

--- a/WebPhapp/PharmaChain/contracts/PrescriptionData.sol
+++ b/WebPhapp/PharmaChain/contracts/PrescriptionData.sol
@@ -5,13 +5,23 @@ import "./PrescriptionBase.sol";
 
 contract PrescriptionData is PrescriptionBase {
 
-    
     Prescription[] public drugChain;
 
-    function getPrescription(uint chainIndex) public view returns (uint256, uint128, uint128, uint64, string, uint64[16], uint64, uint16, uint8, bool, uint64){
+    function getPrescription(uint chainIndex) public view returns (uint256, uint128, uint128, uint64, string, uint64[16], uint64, uint16, uint8, bool, uint64) {
         Prescription memory p = drugChain[chainIndex];
-        return (p.patientID, p.prescriberID, p.dispenserID, p.drugID, p.drugQuantity,
-        p.fulfillmentDates, p.dateWritten, p.daysValid, p.refillsLeft, p.isCancelled, p.cancelDate);
+        return (
+            p.patientID,
+            p.prescriberID,
+            p.dispenserID,
+            p.drugID,
+            p.drugQuantity,
+            p.fulfillmentDates,
+            p.dateWritten,
+            p.daysValid,
+            p.refillsLeft,
+            p.isCancelled,
+            p.cancelDate
+        );
     }
 
     function getDrugChainLength() public view returns (uint) {
@@ -19,7 +29,7 @@ contract PrescriptionData is PrescriptionBase {
     }
     
     function isValidIndex(uint chainIndex) public view returns (uint) {
-        if(0 <= chainIndex && chainIndex < getDrugChainLength()){
+        if(0 <= chainIndex && chainIndex < getDrugChainLength()) {
             return 0;
         }
         //invalid chain index
@@ -27,7 +37,7 @@ contract PrescriptionData is PrescriptionBase {
     }
 
     function updatePrescription(uint chainIndex, uint128 dispenserID, string drugQuantity, 
-            uint16 daysValid,uint8 refillsLeft) public returns(uint) {
+                                uint16 daysValid, uint8 refillsLeft) public returns(uint) {
     	Prescription storage p = drugChain[chainIndex];
         if(p.isCancelled == true){
             //Prescription cancelled, cannot edit, error
@@ -41,29 +51,31 @@ contract PrescriptionData is PrescriptionBase {
         return 0;
     }
 
-    function addPrescription(
-        uint256 patientID,
-        uint128 prescriberID,
-        uint128 dispenserID,
-        uint64 drugID,
-        string memory drugQuantity, 
-        uint64[16] memory fulfillmentDates,
-        uint64 dateWritten,  
-        uint16 daysValid,
-        uint8 refillsLeft,
-        bool isCancelled, 
-        uint64 cancelDate) public returns (uint) {
-        Prescription memory p = Prescription(patientID,prescriberID,dispenserID,drugID,drugQuantity,
-        fulfillmentDates,dateWritten, daysValid, refillsLeft,bool(isCancelled), cancelDate);
+    function addPrescription(uint256 patientID, uint128 prescriberID, uint128 dispenserID, uint64 drugID, string memory drugQuantity,
+                             uint64[16] memory fulfillmentDates, uint64 dateWritten, uint16 daysValid,
+                             uint8 refillsLeft, bool isCancelled, uint64 cancelDate) public returns (uint) {
+        Prescription memory p = Prescription(
+            patientID,
+            prescriberID,
+            dispenserID,
+            drugID,
+            drugQuantity,
+            fulfillmentDates,
+            dateWritten,
+            daysValid,
+            refillsLeft,
+            bool(isCancelled),
+            cancelDate
+        );
 
         drugChain.push(p);
         return drugChain.length -1;
     }
 
-    function cancelPrescription(uint chainIndex, uint64 date) public returns (uint){
+    function cancelPrescription(uint chainIndex, uint64 date) public returns (uint) {
     	// Prescription storage p = drugChain[chainIndex];
-    	if(drugChain[chainIndex].isCancelled){
-		// Prescription already cancelled, error
+    	if(drugChain[chainIndex].isCancelled) {
+		    // Prescription already cancelled, error
             return 1;
         }
         
@@ -72,27 +84,24 @@ contract PrescriptionData is PrescriptionBase {
         return 0;
     }
 
-    function redeemPrescription(uint chainIndex, uint64 date) public returns (uint){
+    function redeemPrescription(uint chainIndex, uint64 date) public returns (uint) {
         Prescription storage p = drugChain[chainIndex];
-	if(p.isCancelled){
+        if(p.isCancelled) {
             //cannot refill cancelled prescription
             return 1;
-	}
-        if (p.refillsLeft == 0){
+        }
+        if (p.refillsLeft == 0) {
             //cannot refill empty prescription
             return 2;
         }
         p.refillsLeft = p.refillsLeft - 1;
-        for(uint64 i = 0; i < 16; i++){
-            if(p.fulfillmentDates[i] == 0){
+        for(uint64 i = 0; i < 16; i++) {
+            if(p.fulfillmentDates[i] == 0) {
                 p.fulfillmentDates[i] = date;
                 break;
                 //NOTE we need to discuss what happens if initial refillsLeft > 16
             }
         }
 	return 0;
-        
-        
-    }
-            
+    }     
 }

--- a/WebPhapp/PharmaChain/load_data.js
+++ b/WebPhapp/PharmaChain/load_data.js
@@ -35,13 +35,21 @@ async function loadPrescriptions(){
 	for (var j = 0; j < obj.prescriptions.length; j++){
 	    p = obj.prescriptions[j];
             
-            //Temp variable to store fillDates
-            let fillDates = [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]
-            for (var i = 0; i < p.fillDates.length; i++){
-	        if(p.fillDates[i] > 0){
-	            fillDates[i] = p.fillDates[i]
-                }	
-	    }
+		//Temp variable to store fillDates
+		let fillDates = [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]
+		for (var i = 0; i < p.fillDates.length; i++){
+			if(p.fillDates[i] > 0){
+				fillDates[i] = p.fillDates[i]
+				}
+		}
+		
+		if(p.cancelDate < 0){
+			p.cancelDate = 0;
+			p.isCancelled = false;
+		}
+		else {
+			p.isCancelled = true;
+		}
 
 	    let transaction = await Patient.methods.addPrescription(
 		p.patientID,
@@ -49,11 +57,11 @@ async function loadPrescriptions(){
 		p.dispenserID,
 		p.drugID,
 		p.quantity,
-		fillDates, //p.fillDates,
+		fillDates,
 		p.writtenDate,
 		p.daysFor,
 		p.refillsLeft,
-		false, //fix once data format between block and front/backend is changed,
+		p.isCancelled,
 		p.cancelDate
 	    );
 	

--- a/WebPhapp/PharmaChain/test/TestPrescriptionData.sol
+++ b/WebPhapp/PharmaChain/test/TestPrescriptionData.sol
@@ -78,8 +78,8 @@ contract TestPrescriptionData is PrescriptionBase{
         uint index = p.addPrescription(data.patientID, data.prescriberID, data.dispenserID, data.drugID,
         data.drugQuantity, data.fulfillmentDates, data.dateWritten, data.daysValid, data.refillsLeft,
         data.isCancelled, data.cancelDate);
-        uint256 cancelled = p.cancellPrescription(index, 10);
-        Assert.equal(uint256(cancelled),uint64(0), "Prescription not cancelled...");
+        uint256 canceled = p.cancelPrescription(index, 10);
+        Assert.equal(uint256(canceled),uint64(0), "Prescription not cancelled...");
     }
     
     //Tests redeeming a prescription

--- a/WebPhapp/PharmaChain/test/TestPrescriptionData.sol
+++ b/WebPhapp/PharmaChain/test/TestPrescriptionData.sol
@@ -54,9 +54,12 @@ contract TestPrescriptionData is PrescriptionBase{
 
 	//Test ability to update a prescription
     function testUpdate() public{
-		uint index = pContract.updatePrescription(data.patientID, data.prescriberID, data.dispenserID, data.drugID,
+		uint index = p.addPrescription(data.patientID, data.prescriberID, data.dispenserID, data.drugID,
         data.drugQuantity, data.fulfillmentDates, data.dateWritten, data.daysValid, data.refillsLeft,
         data.isCancelled, data.cancelDate);
+	p.updatePrescription(index, (data.dispenserID + 1), data.drugQuantity, data.fulfillmentDates, data.daysValid, data.isCancelled, data.cancelDate);
+
+	
         
 
         uint256 patientID;
@@ -73,8 +76,8 @@ contract TestPrescriptionData is PrescriptionBase{
 
 
          //Max local args is 16, limit reached. So last values are not compared
-        (patientID, prescriberID, dispenserID, drugID, drugQuantity, fulfillmentDates, dateWritten, , , , ) = pContract.getPrescription(index);
-        Assert.equal(patientID, data.patientID, "PatientID error....");
+        (patientID, prescriberID, dispenserID, , , , , , , , ) = p.getPrescription(index);
+        Assert.equal(uint (dispenserID), uint (data.dispenserID + 1), "dispenserID not updated error....");
 	}
     
     // Tests the results of an improper access for a prescription. 

--- a/WebPhapp/PharmaChain/test/TestPrescriptionData.sol
+++ b/WebPhapp/PharmaChain/test/TestPrescriptionData.sol
@@ -53,8 +53,6 @@ contract TestPrescriptionData is PrescriptionBase{
     }
 
 	//Test ability to update a prescription
-	//TODO Fix
-	/*
     function testUpdate() public{
 		uint index = p.addPrescription(data.patientID, data.prescriberID, data.dispenserID, data.drugID,
         data.drugQuantity, data.fulfillmentDates, data.dateWritten, data.daysValid, data.refillsLeft,
@@ -74,7 +72,6 @@ contract TestPrescriptionData is PrescriptionBase{
 
         Assert.equal(uint (dispenserID), uint (data.dispenserID + 1), "dispenserID not updated error....");
     }
-	*/
 
     //Tests adding then cancelling a prescription
     function testCancel() public{

--- a/WebPhapp/PharmaChain/test/TestPrescriptionData.sol
+++ b/WebPhapp/PharmaChain/test/TestPrescriptionData.sol
@@ -57,7 +57,7 @@ contract TestPrescriptionData is PrescriptionBase{
 		uint index = p.addPrescription(data.patientID, data.prescriberID, data.dispenserID, data.drugID,
         data.drugQuantity, data.fulfillmentDates, data.dateWritten, data.daysValid, data.refillsLeft,
         data.isCancelled, data.cancelDate);
-	p.updatePrescription(index, 3, data.drugQuantity, data.daysValid);
+	p.updatePrescription(index, 3, data.drugQuantity, data.daysValid, data.refillsLeft);
 
 	
         

--- a/WebPhapp/PharmaChain/test/TestPrescriptionData.sol
+++ b/WebPhapp/PharmaChain/test/TestPrescriptionData.sol
@@ -28,7 +28,6 @@ contract TestPrescriptionData is PrescriptionBase{
         cancelDate: 0
     });
 
-
     // Test the ability to add a prescription
     function testAddingPrescription() public {
         uint index = p.addPrescription(data.patientID, data.prescriberID, data.dispenserID, data.drugID,
@@ -54,22 +53,34 @@ contract TestPrescriptionData is PrescriptionBase{
 
 	//Test ability to update a prescription
     function testUpdate() public{
-		uint index = p.addPrescription(data.patientID, data.prescriberID, data.dispenserID, data.drugID,
-        data.drugQuantity, data.fulfillmentDates, data.dateWritten, data.daysValid, data.refillsLeft,
-        data.isCancelled, data.cancelDate);
-	p.updatePrescription(index, 3, data.drugQuantity, data.daysValid, data.refillsLeft);
+        uint index = p.addPrescription(
+            data.patientID,
+            data.prescriberID,
+            data.dispenserID,
+            data.drugID,
+            data.drugQuantity,
+            data.fulfillmentDates,
+            data.dateWritten,
+            data.daysValid,
+            data.refillsLeft,
+            data.isCancelled,
+            data.cancelDate
+        );
 
-	
-        
+        p.updatePrescription(
+            index,
+            3,
+            data.drugQuantity,
+            data.daysValid,
+            data.refillsLeft
+        );
 
         uint256 patientID;
         uint128 prescriberID;
         uint128 dispenserID;
 
-
          //Max local args is 16, limit reached. So last values are not compared
         (patientID, prescriberID, dispenserID, , , , , , , , ) = p.getPrescription(index);
-
         Assert.equal(uint (dispenserID), uint (data.dispenserID + 1), "dispenserID not updated error....");
     }
 
@@ -94,17 +105,12 @@ contract TestPrescriptionData is PrescriptionBase{
         uint128 dispenserID;
         uint128 refillsLeft;
 
-
          //Max local args is 16, limit reached. So last values are not compared
         (patientID, prescriberID, dispenserID, , , , , , refillsLeft, , ) = p.getPrescription(index);
         Assert.equal(uint(0), uint(redeem), "Unsucessful redemption");
         Assert.equal(uint(refillsLeft), uint(data.refillsLeft - 1), "Refills not decremented");
-              
-        
-
     }
 
-    
     // Tests the results of an improper access for a prescription. 
     function testImproperChainIndexCheck() public {
         bool result = DeployedAddresses.Patient().call(bytes4(bytes32(keccak256("getPatientPrescription(2)"))));

--- a/WebPhapp/PharmaChain/test/TestPrescriptionData.sol
+++ b/WebPhapp/PharmaChain/test/TestPrescriptionData.sol
@@ -59,7 +59,7 @@ contract TestPrescriptionData is PrescriptionBase{
 		uint index = p.addPrescription(data.patientID, data.prescriberID, data.dispenserID, data.drugID,
         data.drugQuantity, data.fulfillmentDates, data.dateWritten, data.daysValid, data.refillsLeft,
         data.isCancelled, data.cancelDate);
-	p.updatePrescription(index, 3, data.drugQuantity, data.fulfillmentDates, data.daysValid, data.isCancelled, data.cancelDate);
+	p.updatePrescription(index, 3, data.drugQuantity, data.daysValid);
 
 	
         

--- a/WebPhapp/PharmaChain/test/TestPrescriptionData.sol
+++ b/WebPhapp/PharmaChain/test/TestPrescriptionData.sol
@@ -65,14 +65,6 @@ contract TestPrescriptionData is PrescriptionBase{
         uint256 patientID;
         uint128 prescriberID;
         uint128 dispenserID;
-        uint64 drugID;
-        string memory drugQuantity;
-        uint64[16] memory fulfillmentDates;
-        uint64 dateWritten;
-
-        uint16 daysValid;
-        bool isCancelled;
-        uint64 cancelDate;
 
 
          //Max local args is 16, limit reached. So last values are not compared

--- a/WebPhapp/PharmaChain/test/TestPrescriptionData.sol
+++ b/WebPhapp/PharmaChain/test/TestPrescriptionData.sol
@@ -51,6 +51,31 @@ contract TestPrescriptionData is PrescriptionBase{
         Assert.equal(uint(prescriberID), uint(data.prescriberID), "PrescriberID error....");
         Assert.equal(string(drugQuantity), string(data.drugQuantity), "Drug quantity error....");
     }
+
+	//Test ability to update a prescription
+    function testUpdate() public{
+		uint index = pContract.updatePrescription(data.patientID, data.prescriberID, data.dispenserID, data.drugID,
+        data.drugQuantity, data.fulfillmentDates, data.dateWritten, data.daysValid, data.refillsLeft,
+        data.isCancelled, data.cancelDate);
+        
+
+        uint256 patientID;
+        uint128 prescriberID;
+        uint128 dispenserID;
+        uint64 drugID;
+        string memory drugQuantity;
+        uint64[16] memory fulfillmentDates;
+        uint64 dateWritten;
+
+        uint16 daysValid;
+        bool isCancelled;
+        uint64 cancelDate;
+
+
+         //Max local args is 16, limit reached. So last values are not compared
+        (patientID, prescriberID, dispenserID, drugID, drugQuantity, fulfillmentDates, dateWritten, , , , ) = pContract.getPrescription(index);
+        Assert.equal(patientID, data.patientID, "PatientID error....");
+	}
     
     // Tests the results of an improper access for a prescription. 
     function testImproperChainIndexCheck() public {

--- a/WebPhapp/PharmaChain/test/TestPrescriptionData.sol
+++ b/WebPhapp/PharmaChain/test/TestPrescriptionData.sol
@@ -13,7 +13,7 @@ contract TestPrescriptionData is PrescriptionBase{
     
     Patient p = Patient(DeployedAddresses.Patient());
 
-    uint64[16] fu; // cannot assign arrays as a constant. So, this var must be here.
+    uint64[16] fu = [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]; // cannot assign arrays as a constant. So, this var must be here.
     Prescription data = Prescription({
         patientID: 0,
         prescriberID: 1,
@@ -53,11 +53,13 @@ contract TestPrescriptionData is PrescriptionBase{
     }
 
 	//Test ability to update a prescription
+	//TODO Fix
+	/*
     function testUpdate() public{
 		uint index = p.addPrescription(data.patientID, data.prescriberID, data.dispenserID, data.drugID,
         data.drugQuantity, data.fulfillmentDates, data.dateWritten, data.daysValid, data.refillsLeft,
         data.isCancelled, data.cancelDate);
-	p.updatePrescription(index, (data.dispenserID + 1), data.drugQuantity, data.fulfillmentDates, data.daysValid, data.isCancelled, data.cancelDate);
+	p.updatePrescription(index, 3, data.drugQuantity, data.fulfillmentDates, data.daysValid, data.isCancelled, data.cancelDate);
 
 	
         
@@ -69,8 +71,42 @@ contract TestPrescriptionData is PrescriptionBase{
 
          //Max local args is 16, limit reached. So last values are not compared
         (patientID, prescriberID, dispenserID, , , , , , , , ) = p.getPrescription(index);
+
         Assert.equal(uint (dispenserID), uint (data.dispenserID + 1), "dispenserID not updated error....");
-	}
+    }
+	*/
+
+    //Tests adding then cancelling a prescription
+    function testCancel() public{
+        uint index = p.addPrescription(data.patientID, data.prescriberID, data.dispenserID, data.drugID,
+        data.drugQuantity, data.fulfillmentDates, data.dateWritten, data.daysValid, data.refillsLeft,
+        data.isCancelled, data.cancelDate);
+        uint256 cancelled = p.cancellPrescription(index, 10);
+        Assert.equal(uint256(cancelled),uint64(0), "Prescription not cancelled...");
+    }
+    
+    //Tests redeeming a prescription
+    function testRedeem() public{
+        uint index = p.addPrescription(data.patientID, data.prescriberID, data.dispenserID, data.drugID,
+            data.drugQuantity, data.fulfillmentDates, data.dateWritten, data.daysValid, data.refillsLeft,
+            data.isCancelled, data.cancelDate);
+        uint redeem = p.redeemPrescription(index, 10);
+ 
+        uint256 patientID;
+        uint128 prescriberID;
+        uint128 dispenserID;
+        uint128 refillsLeft;
+
+
+         //Max local args is 16, limit reached. So last values are not compared
+        (patientID, prescriberID, dispenserID, , , , , , refillsLeft, , ) = p.getPrescription(index);
+        Assert.equal(uint(0), uint(redeem), "Unsucessful redemption");
+        Assert.equal(uint(refillsLeft), uint(data.refillsLeft - 1), "Refills not decremented");
+              
+        
+
+    }
+
     
     // Tests the results of an improper access for a prescription. 
     function testImproperChainIndexCheck() public {

--- a/WebPhapp/PharmaChain/truffle.js
+++ b/WebPhapp/PharmaChain/truffle.js
@@ -20,8 +20,7 @@ module.exports = {
 			host: "10.50.0.2",
 			port: 22000,
 			network_id: "*",
-			gasPrice: 0,
-			gas: 999999909
+			gasPrice: 0
 			
 		}
 	},

--- a/WebPhapp/PharmaChain/update_prescription.js
+++ b/WebPhapp/PharmaChain/update_prescription.js
@@ -4,11 +4,11 @@ let net = require("net");
 
 /*  This function updates an existing prescription on the drugChain
     User input: prescription arguments
-    Argument list: drugChainIndex, dispenserID, drugQuantity, daysValid, isCancelled, cancelDate
-    Example usage: node update_prescription.js 0 1 2 4 true 8    
+    Argument list: drugChainIndex, dispenserID, drugQuantity, daysValid
+    Example usage: node update_prescription.js 0 1 2 4   
 */
 
-async function update( drugChainIndex, dispenserID,drugQuantity, fulfillmentDate, daysValid, isCancelled, cancelDate){
+async function update( drugChainIndex, dispenserID, drugQuantity, daysValid){
 
     // Connecting to the node 1. Will want to change to IPC connection eventually. 
 	let web3 = new Web3( new Web3.providers.HttpProvider("http://10.50.0.2:22000", net));
@@ -28,8 +28,7 @@ async function update( drugChainIndex, dispenserID,drugQuantity, fulfillmentDate
 
     // Set up prescription data to be sent.
     Patient.options.address = fs.readFileSync("./patient_contract_address.txt").toString('ascii');
-    let transaction = await Patient.methods.updatePrescription(drugChainIndex, dispenserID,drugQuantity, 
-                                                        fulfillmentDate, daysValid, isCancelled, cancelDate);
+    let transaction = await Patient.methods.updatePrescription(drugChainIndex, dispenserID, drugQuantity, daysValid);
     
     // Submitting prescription transaction.
     let encoded_transaction = transaction.encodeABI();
@@ -51,10 +50,6 @@ let args = process.argv
 let drugChainIndex= args[2];
 let dispenserID = args[3];
 let drugQuantity = args[4]; 
-// Must be a 16 element int array in order to work. 
-let fulfillmentDate = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] 
-let daysValid = args[5];
-let isCancelled = args[6];
-let cancelDate = args[7];
+let daysValid = args[5]
 
-update(drugChainIndex, dispenserID, drugQuantity, fulfillmentDate, daysValid, isCancelled, cancelDate);
+update(drugChainIndex, dispenserID, drugQuantity, daysValid);

--- a/WebPhapp/PharmaChain/update_prescription.js
+++ b/WebPhapp/PharmaChain/update_prescription.js
@@ -18,7 +18,7 @@ async function update( drugChainIndex, dispenserID,drugQuantity, fulfillmentDate
     account = account[0];
 
     // Sets up deployment requirements
-    let source = fs.readFileSync('/home/osboxes/PharmaChain/build/contracts/Patient.json'); 
+    let source = fs.readFileSync('./build/contracts/Patient.json'); 
     let contracts = JSON.parse(source);
     let code = contracts.bytecode;
     let abi = contracts.abi;

--- a/WebPhapp/PharmaChain/update_prescription.js
+++ b/WebPhapp/PharmaChain/update_prescription.js
@@ -57,4 +57,4 @@ let daysValid = args[5];
 let isCancelled = args[6];
 let cancelDate = args[7];
 
-update( drugChainIndex, dispenserID,drugQuantity, fulfillmentDate, daysValid, isCancelled, cancelDate);
+update(drugChainIndex, dispenserID, drugQuantity, fulfillmentDate, daysValid, isCancelled, cancelDate);

--- a/WebPhapp/PharmaChain/update_prescription.js
+++ b/WebPhapp/PharmaChain/update_prescription.js
@@ -4,11 +4,11 @@ let net = require("net");
 
 /*  This function updates an existing prescription on the drugChain
     User input: prescription arguments
-    Argument list: drugChainIndex, dispenserID, drugQuantity, daysValid
-    Example usage: node update_prescription.js 0 1 2 4   
+    Argument list: drugChainIndex, dispenserID, drugQuantity, daysValid, refillsLeft
+    Example usage: node update_prescription.js 0 1 2 4 8
 */
 
-async function update( drugChainIndex, dispenserID, drugQuantity, daysValid){
+async function update( drugChainIndex, dispenserID, drugQuantity, daysValid, refillsLeft){
 
     // Connecting to the node 1. Will want to change to IPC connection eventually. 
 	let web3 = new Web3( new Web3.providers.HttpProvider("http://10.50.0.2:22000", net));
@@ -28,7 +28,7 @@ async function update( drugChainIndex, dispenserID, drugQuantity, daysValid){
 
     // Set up prescription data to be sent.
     Patient.options.address = fs.readFileSync("./patient_contract_address.txt").toString('ascii');
-    let transaction = await Patient.methods.updatePrescription(drugChainIndex, dispenserID, drugQuantity, daysValid);
+    let transaction = await Patient.methods.updatePrescription(drugChainIndex, dispenserID, drugQuantity, daysValid, refillsLeft);
     
     // Submitting prescription transaction.
     let encoded_transaction = transaction.encodeABI();
@@ -50,6 +50,7 @@ let args = process.argv
 let drugChainIndex= args[2];
 let dispenserID = args[3];
 let drugQuantity = args[4]; 
-let daysValid = args[5]
+let daysValid = args[5];
+let refillsLeft - args[6];
 
-update(drugChainIndex, dispenserID, drugQuantity, daysValid);
+update(drugChainIndex, dispenserID, drugQuantity, daysValid, refillsLeft);

--- a/WebPhapp/PharmaChain/update_prescription.js
+++ b/WebPhapp/PharmaChain/update_prescription.js
@@ -2,10 +2,17 @@ let fs = require("fs");
 let Web3 = require("web3");
 let net = require("net");
 
-/*  This function updates an existing prescription on the drugChain
-    User input: prescription arguments
-    Argument list: drugChainIndex, dispenserID, drugQuantity, daysValid, refillsLeft
-    Example usage: node update_prescription.js 0 1 2 4 8
+/*  
+This function updates an existing prescription on the drugChain
+User input: prescription arguments
+Args:
+    chainIndex (int)
+    dispenserID (int)
+    drugQuantity (string)
+    daysValid (int)
+    refillsLeft (int)
+Example: 
+    >>> sudo node update_prescription.js 0 1 "1 mg" 4 8
 */
 
 async function update( drugChainIndex, dispenserID, drugQuantity, daysValid, refillsLeft){
@@ -41,11 +48,9 @@ async function update( drugChainIndex, dispenserID, drugQuantity, daysValid, ref
     
     // Return Transaction object containing transaction hash and other data
     return block;
-
 }
 
-// Main: 
-
+// Main:
 let args = process.argv
 let drugChainIndex= args[2];
 let dispenserID = args[3];

--- a/WebPhapp/PharmaChain/write_prescription.js
+++ b/WebPhapp/PharmaChain/write_prescription.js
@@ -33,7 +33,20 @@ async function write(patientID, prescriberID, dispenserID, drugID, drugQuantity,
 	
     // Set up prescription data to be sent.
     Patient.options.address = fs.readFileSync("./patient_contract_address.txt").toString('ascii');
-    let transaction = await Patient.methods.addPrescription(patientID, prescriberID, dispenserID, drugID, drugQuantity, fulfillmentDates, dateWritten, daysValid, refillsLeft, cancelled, cancelDate);
+    let transaction = await Patient.methods.addPrescription(
+        patientID,
+        prescriberID,
+        dispenserID,
+        drugID,
+        drugQuantity,
+        fulfillmentDates,
+        dateWritten,
+        daysValid,
+        refillsLeft,
+        cancelled,
+        cancelDate
+    );
+
     // Submitting prescription transaction.
     let encoded_transaction = transaction.encodeABI();
     let block = await web3.eth.sendTransaction({
@@ -45,7 +58,6 @@ async function write(patientID, prescriberID, dispenserID, drugID, drugQuantity,
     
     // Return Transaction object containing transaction hash and other data
     return block;
-
 }
 
 // Main: 
@@ -56,8 +68,7 @@ let prescriberID = args[3];
 let dispenserID = args[4];
 let drugID = args[5];
 let drugQuantity = args[6]; 
-// Must be a 16 element int array in order to work. 
-let fulfillmentDates = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+let fulfillmentDates = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] // Must be a 16 element int array in order to work. 
 let dateWritten = args[7];  
 let daysValid = args[8];
 let refillsLeft = args[9];

--- a/WebPhapp/PharmaChain/write_prescription.js
+++ b/WebPhapp/PharmaChain/write_prescription.js
@@ -25,12 +25,15 @@ async function write(patientID, prescriberID, dispenserID, drugID, drugQuantity,
     let Patient = new web3.eth.Contract(abi, null,{
         data: code,
     });
-
+	
+	var cancelled = false;
+	if(isCancelled == "true"){
+		cancelled  = true;
+	}
+	
     // Set up prescription data to be sent.
     Patient.options.address = fs.readFileSync("./patient_contract_address.txt").toString('ascii');
-    let transaction = await Patient.methods.addPrescription(patientID, prescriberID, dispenserID, drugID, drugQuantity,
-                                                         fulfillmentDates, dateWritten, daysValid, refillsLeft, isCancelled, cancelDate);
-    
+    let transaction = await Patient.methods.addPrescription(patientID, prescriberID, dispenserID, drugID, drugQuantity, fulfillmentDates, dateWritten, daysValid, refillsLeft, cancelled, cancelDate);
     // Submitting prescription transaction.
     let encoded_transaction = transaction.encodeABI();
     let block = await web3.eth.sendTransaction({

--- a/WebPhapp/backend/block_helper.js
+++ b/WebPhapp/backend/block_helper.js
@@ -224,10 +224,19 @@ module.exports = {
     cancel: async function(index_value, date) {
         var blockchain = await connectToChain();
         var error;
-        var result;
+        var block;
 
         try {
-            result = await blockchain.patient.methods.cancelPrescription(index_value, date).call({from: blockchain.account});
+            let transaction = await blockchain.patient.methods.cancelPrescription(index_value, date).call({from: blockchain.account});
+            
+            // Submitting prescription transaction.
+            let encoded_transaction = transaction.encodeABI();
+            block = await blockchain.web3.eth.sendTransaction({
+                data: encoded_transaction,
+                from: blockchain.account,
+                to: blockchain.patient.options.address,
+                gas: 50000000
+            });
         }
         catch(err) {
             error = err;
@@ -235,10 +244,11 @@ module.exports = {
 
         return new Promise((resolve, reject) => {
             if(error) reject(error);
-            resolve(result);
+            resolve(block);
         });
     },
 
+    // missing refills left field
     update: async function(index_value, dispenserID, drugQuantity, daysValid) {
         var blockchain = await connectToChain();
         var error;

--- a/WebPhapp/backend/block_helper.js
+++ b/WebPhapp/backend/block_helper.js
@@ -195,8 +195,10 @@ module.exports = {
     redeem: async function(index_value, date) {
         var blockchain = await connectToChain();
         var error;
+        var result;
+
         try {
-            let result = await blockchain.patient.methods.redeemPrescription(index_value, date).call({from: blockchain.account});
+            result = await blockchain.patient.methods.redeemPrescription(index_value, date).call({from: blockchain.account});
         }
         catch(err) {
             error = err;
@@ -204,6 +206,7 @@ module.exports = {
 
         return new Promise((resolve, reject) => {
             if(error) reject(error);
+            resolve(result);
         });
     },
 
@@ -221,23 +224,27 @@ module.exports = {
     cancel: async function(index_value, date) {
         var blockchain = await connectToChain();
         var error;
+        var result;
+
         try {
-            let result = await blockchain.patient.methods.cancelPrescription(index_value, date).call({from: blockchain.account});
-        }a
+            result = await blockchain.patient.methods.cancelPrescription(index_value, date).call({from: blockchain.account});
+        }
         catch(err) {
             error = err;
         }
 
         return new Promise((resolve, reject) => {
             if(error) reject(error);
+            resolve(result);
         });
     },
 
     update: async function(index_value, dispenserID, drugQuantity, daysValid) {
         var blockchain = await connectToChain();
         var error;
+        var update;
         try {
-            let update = await blockchain.patient.methods.updatePrescription(
+            update = await blockchain.patient.methods.updatePrescription(
                 index_value,
                 dispenserID,
                 drugQuantity,
@@ -250,6 +257,7 @@ module.exports = {
         }
         return new Promise((resolve, reject) => {
             if(error) reject(error);
+            resolve(update);
         });
     }
 }

--- a/WebPhapp/backend/block_helper.js
+++ b/WebPhapp/backend/block_helper.js
@@ -190,45 +190,15 @@ module.exports = {
     Returns:
         Transaction object
     Example:
-        redeem(0)
+        redeem(0, 123456543)
     */
     redeem: async function(index_value, date) {
-        var blockchain = await connectToChain();
-        var error;
-        var result;
-
-        try {
-            result = await blockchain.patient.methods.redeemPrescription(index_value, date).call({from: blockchain.account});
-        }
-        catch(err) {
-            error = err;
-        }
-
-        return new Promise((resolve, reject) => {
-            if(error) reject(error);
-            resolve(result);
-        });
-    },
-
-    /*
-    This function cancels a prescription on the blockchain,
-        preventing it from being updated or altered
-    Args:
-        index_value
-        date
-    Returns:
-        0 if successful else non-zero integer.
-    Example:
-        cancel(0, 123456543)
-    */
-    cancel: async function(index_value, date) {
         var blockchain = await connectToChain();
         var error;
         var block;
 
         try {
-            let transaction = await blockchain.patient.methods.cancelPrescription(index_value, date).call({from: blockchain.account});
-            
+            let transaction = await blockchain.patient.methods.redeemPrescription(index_value, date);
             // Submitting prescription transaction.
             let encoded_transaction = transaction.encodeABI();
             block = await blockchain.web3.eth.sendTransaction({
@@ -248,19 +218,76 @@ module.exports = {
         });
     },
 
-    // missing refills left field
-    update: async function(index_value, dispenserID, drugQuantity, daysValid) {
+    /*
+    This function cancels a prescription on the blockchain,
+        preventing it from being updated or altered
+    Args:
+        index_value
+        date
+    Returns:
+        Transaction object.
+    Example:
+        cancel(0, 123456543)
+    */
+    cancel: async function(index_value, date) {
+        var blockchain = await connectToChain();
+        var error;
+        var block;
+
+        try {
+            let transaction = await blockchain.patient.methods.cancelPrescription(index_value, date);
+            // Submitting prescription transaction.
+            let encoded_transaction = transaction.encodeABI();
+            block = await blockchain.web3.eth.sendTransaction({
+                data: encoded_transaction,
+                from: blockchain.account,
+                to: blockchain.patient.options.address,
+                gas: 50000000
+            });
+        }
+        catch(err) {
+            error = err;
+        }
+
+        return new Promise((resolve, reject) => {
+            if(error) reject(error);
+            resolve(block);
+        });
+    },
+
+    /*
+    This function updates a prescription on the blockchain,
+        altering its dispenserID, drugQuantity, daysValid, 
+    Args:
+        index_value
+        dispenserID
+        drugQuantity,
+        daysValid,
+        refillsLeft
+    Returns:
+        Transactiono Object.
+    Example:
+        update(0, 2, '300MG', 16)
+    */
+    update: async function(index_value, dispenserID, drugQuantity, daysValid, refillsLeft) {
         var blockchain = await connectToChain();
         var error;
         var update;
         try {
-            update = await blockchain.patient.methods.updatePrescription(
+            let transaction = await blockchain.patient.methods.updatePrescription(
                 index_value,
                 dispenserID,
                 drugQuantity,
                 daysValid
             );
-    
+
+            let encoded_transaction = transaction.encodeABI();
+            block = await blockchain.web3.eth.sendTransaction({
+                data: encoded_transaction,
+                from: blockchain.account,
+                to: blockchain.patient.options.address,
+                gas: 50000000
+            });
         }
         catch(err) {
             error = err;

--- a/WebPhapp/backend/block_helper.js
+++ b/WebPhapp/backend/block_helper.js
@@ -217,9 +217,9 @@ module.exports = {
         index_value
         date
     Returns:
-        Transaction object
+        0 if successful else non-zero integer.
     Example:
-        cancel(0)
+        cancel(0, 123456543)
     */
     cancel: async function(index_value, date) {
         var blockchain = await connectToChain();

--- a/WebPhapp/backend/block_helper.js
+++ b/WebPhapp/backend/block_helper.js
@@ -179,5 +179,31 @@ module.exports = {
         
         // Return Transaction object containing transaction hash and other data
         return block;
-    }
+    },
+
+    /*
+    This function redeems a prescription on the blockchain
+    Args:
+        index_value
+        date
+    Returns:
+        Transaction object
+    Example:
+        redeem(0)
+    */
+    redeem: async function(index_value, date) {
+        var blockchain = await connectToChain();
+        var error;
+        try {
+            let result = await blockchain.patient.methods.redeemPrescription(index_value, date).call({from: blockchain.account});
+        }
+        catch(err) {
+            error = err;
+        }
+
+        return new Promise((resolve, reject) => {
+            if(error) reject(error);
+        });
+    }   
+
 }

--- a/WebPhapp/backend/block_helper.js
+++ b/WebPhapp/backend/block_helper.js
@@ -182,7 +182,8 @@ module.exports = {
     },
 
     /*
-    This function redeems a prescription on the blockchain
+    This function redeems a prescription on the blockchain,
+	decrementing refills left, and adding a new date to fulfillmentDates
     Args:
         index_value
         date
@@ -204,6 +205,8 @@ module.exports = {
         return new Promise((resolve, reject) => {
             if(error) reject(error);
         });
-    }   
+    },
+
+   
 
 }

--- a/WebPhapp/backend/block_helper.js
+++ b/WebPhapp/backend/block_helper.js
@@ -207,6 +207,49 @@ module.exports = {
         });
     },
 
-   
+    /*
+    This function cancels a prescription on the blockchain,
+        preventing it from being updated or altered
+    Args:
+        index_value
+        date
+    Returns:
+        Transaction object
+    Example:
+        cancel(0)
+    */
+    cancel: async function(index_value, date) {
+        var blockchain = await connectToChain();
+        var error;
+        try {
+            let result = await blockchain.patient.methods.cancelPrescription(index_value, date).call({from: blockchain.account});
+        }a
+        catch(err) {
+            error = err;
+        }
 
+        return new Promise((resolve, reject) => {
+            if(error) reject(error);
+        });
+    },
+
+    update: async function(index_value, dispenserID, drugQuantity, daysValid) {
+        var blockchain = await connectToChain();
+        var error;
+        try {
+            let update = await blockchain.patient.methods.updatePrescription(
+                index_value,
+                dispenserID,
+                drugQuantity,
+                daysValid
+            );
+    
+        }
+        catch(err) {
+            error = err;
+        }
+        return new Promise((resolve, reject) => {
+            if(error) reject(error);
+        });
+    }
 }

--- a/WebPhapp/backend/block_helper.js
+++ b/WebPhapp/backend/block_helper.js
@@ -70,14 +70,14 @@ module.exports = {
     Returns:
         { prescription }
     */
-    read: async function(index_value) {
+    read: async function(chainIndex) {
         var blockchain = await connectToChain();
 
         var error;
         let prescription = {};
         try {
-            let values = await blockchain.patient.methods.getPrescription(index_value).call({from: blockchain.account});
-            prescription = valuesToPrescription(values, index_value);
+            let values = await blockchain.patient.methods.getPrescription(chainIndex).call({from: blockchain.account});
+            prescription = valuesToPrescription(values, chainIndex);
         }
         catch(err) {
             error = err;
@@ -169,9 +169,9 @@ module.exports = {
         );
         
         // Submitting prescription transaction.
-        let encoded_transaction = transaction.encodeABI();
+        let encodedTransaction = transaction.encodeABI();
         let block = await blockchain.web3.eth.sendTransaction({
-            data: encoded_transaction,
+            data: encodedTransaction,
             from: blockchain.account,
             to: blockchain.patient.options.address,
             gas: 50000000
@@ -185,24 +185,24 @@ module.exports = {
     This function redeems a prescription on the blockchain,
 	decrementing refills left, and adding a new date to fulfillmentDates
     Args:
-        index_value
-        date
+        chainIndex (int)
+        date (int)
     Returns:
         Transaction object
     Example:
         redeem(0, 123456543)
     */
-    redeem: async function(index_value, date) {
+    redeem: async function(chainIndex, date) {
         var blockchain = await connectToChain();
         var error;
         var block;
 
         try {
-            let transaction = await blockchain.patient.methods.redeemPrescription(index_value, date);
+            let transaction = await blockchain.patient.methods.redeemPrescription(chainIndex, date);
             // Submitting prescription transaction.
-            let encoded_transaction = transaction.encodeABI();
+            let encodedTransaction = transaction.encodeABI();
             block = await blockchain.web3.eth.sendTransaction({
-                data: encoded_transaction,
+                data: encodedTransaction,
                 from: blockchain.account,
                 to: blockchain.patient.options.address,
                 gas: 50000000
@@ -222,24 +222,24 @@ module.exports = {
     This function cancels a prescription on the blockchain,
         preventing it from being updated or altered
     Args:
-        index_value
-        date
+        chainIndex (int)
+        date (int)
     Returns:
         Transaction object.
     Example:
         cancel(0, 123456543)
     */
-    cancel: async function(index_value, date) {
+    cancel: async function(chainIndex, date) {
         var blockchain = await connectToChain();
         var error;
         var block;
 
         try {
-            let transaction = await blockchain.patient.methods.cancelPrescription(index_value, date);
+            let transaction = await blockchain.patient.methods.cancelPrescription(chainIndex, date);
             // Submitting prescription transaction.
-            let encoded_transaction = transaction.encodeABI();
+            let encodedTransaction = transaction.encodeABI();
             block = await blockchain.web3.eth.sendTransaction({
-                data: encoded_transaction,
+                data: encodedTransaction,
                 from: blockchain.account,
                 to: blockchain.patient.options.address,
                 gas: 50000000
@@ -257,33 +257,34 @@ module.exports = {
 
     /*
     This function updates a prescription on the blockchain,
-        altering its dispenserID, drugQuantity, daysValid, 
+        altering its dispenserID, drugQuantity, daysValid, and refillsLeft
     Args:
-        index_value
-        dispenserID
-        drugQuantity,
-        daysValid,
-        refillsLeft
+        chainIndex (int)
+        dispenserID (int)
+        drugQuantity (string)
+        daysValid (int)
+        refillsLeft (int)
     Returns:
-        Transactiono Object.
+        Transaction Object.
     Example:
-        update(0, 2, '300MG', 16)
+        update(0, 2, '300MG', 16, 1)
     */
-    update: async function(index_value, dispenserID, drugQuantity, daysValid, refillsLeft) {
+    update: async function(chainIndex, dispenserID, drugQuantity, daysValid, refillsLeft) {
         var blockchain = await connectToChain();
         var error;
-        var update;
+        var block;
         try {
             let transaction = await blockchain.patient.methods.updatePrescription(
-                index_value,
+                chainIndex,
                 dispenserID,
                 drugQuantity,
-                daysValid
+                daysValid,
+                refillsLeft
             );
 
-            let encoded_transaction = transaction.encodeABI();
+            let encodedTransaction = transaction.encodeABI();
             block = await blockchain.web3.eth.sendTransaction({
-                data: encoded_transaction,
+                data: encodedTransaction,
                 from: blockchain.account,
                 to: blockchain.patient.options.address,
                 gas: 50000000
@@ -294,7 +295,7 @@ module.exports = {
         }
         return new Promise((resolve, reject) => {
             if(error) reject(error);
-            resolve(update);
+            resolve(block);
         });
     }
 }

--- a/WebPhapp/backend/block_helper.js
+++ b/WebPhapp/backend/block_helper.js
@@ -61,6 +61,13 @@ var connectToChain = async function() {
     };
 };
 
+// Returns the Integer number of prescriptions stored on the blockchain.
+var getChainLength = async function() {
+    var blockchain = await connectToChain();
+    let length = await blockchain.patient.methods.getDrugChainLength().call({from: blockchain.account});
+    return parseInt(length);
+};
+
 module.exports = {
 
     /*
@@ -323,10 +330,28 @@ module.exports = {
         });
     },
 
-    // Returns the Integer number of prescriptions stored on the blockchain.
-    getChainLength: async function() {
+    /*
+    Checks the length of the blockchain to determine if the given chainIndex is valid for an existing prescription.
+    Args:
+        chainIndex (int)
+    */
+    verifyChainIndex: async function(chainIndex) {
         var blockchain = await connectToChain();
-        let length = await blockchain.patient.methods.getDrugChainLength().call({from: blockchain.account});
-        return parseInt(length);
+        let chainLength;
+        let error;
+
+        try {
+            chainLength = await blockchain.patient.methods.getDrugChainLength().call({from: blockchain.account});
+            if(chainIndex >= parseInt(chainLength)) {
+                throw new Error('verifyChainIndex: given chainIndex is too high to be a valid index on the blockchain.');
+            }
+        } catch (err) {
+            error = err;
+        }
+
+        return new Promise((resolve, reject) => {
+            if(error) reject(error);
+            resolve(true);
+        });
     }
 }

--- a/WebPhapp/backend/server.js
+++ b/WebPhapp/backend/server.js
@@ -55,6 +55,34 @@ function convertDatesToString(prescription){
 // given prescription ID.
 // Example: 
 //      >>> curl "http://localhost:5000/api/v1/prescriptions/cancel/0"
+// app.get('/api/v1/prescriptions/cancel/:prescriptionID', (req,res) => {
+//     var prescriptionID = parseInt(req.params.prescriptionID);
+//     var date = new Date().getTime();
+
+//     //TODO Check for auth to do this.
+//     //TODO Check for valid prescriptionID
+
+//     // finish takes a string message and a boolean (true if successful)
+//     function finish(msg, success){
+//         console.log(msg);
+//         res.status(success ? 200 : 400).json(success);
+//         return;
+//     }
+
+//     if(conn.Blockchain){
+//         console.log(prescriptionID, date);
+//         block_helper.cancel(prescriptionID, date
+//         ).then((answer) => {
+//             console.log(answer);
+//             finish('cancel is WIP ', true);
+//         })
+//         .catch((error) => {
+//             finish("/api/v1/prescriptions/cancel: error: " + error.toString(), false);
+//         });
+//     } else { // cancel prescription from dummy data
+//         finish("cancel tmp: dummy data not changed", true);
+//     }
+// });
 app.get('/api/v1/prescriptions/cancel/:prescriptionID', (req,res) => {
     var prescriptionID = parseInt(req.params.prescriptionID);
     var date = new Date().getTime();
@@ -70,16 +98,17 @@ app.get('/api/v1/prescriptions/cancel/:prescriptionID', (req,res) => {
     }
 
     if(conn.Blockchain){
-        block_helper.cancel(prescriptionID, date)
-        .then((answer) => {
+        console.log(prescriptionID, date);
+        block_helper.cancel(prescriptionID, date
+        ).then((answer) => {
             console.log(answer);
-            finish('cancel is WIP ', true);
+            return finish('cancel is WIP ', true);
         })
         .catch((error) => {
-            finish("/api/v1/prescriptions/cancel: error: " + error.toString(), false);
+            return finish("/api/v1/prescriptions/cancel: error: " + error.toString(), false);
         });
     } else { // cancel prescription from dummy data
-        finish("cancel tmp: dummy data not changed", true);
+        return finish("cancel tmp: dummy data not changed", true);
     }
 });
 
@@ -133,7 +162,30 @@ app.post('/api/v1/prescriptions/edit',(req,res) => {
 
 
     //TODO Go into blockchain to call changing functions...The data for this is in the changedPrescription data.
-    return finish("TODO: build prescription edit to blockchain", true);
+    // finish takes a string message and a boolean (true if successful)
+
+    if(conn.Blockchain){
+        var prescriptionID = changedPrescription.prescriptionID;
+        var dispenserID = changedPrescription.dispenserID;
+        var drugQuantity = changedPrescription.drugQuantity;
+        var daysValid = changedPrescription.daysValid;
+        var refillsLeft = changedPrescription.refillsLeft;
+
+        block_helper.update(prescriptionID,
+            dispenserID,
+            drugQuantity,
+            daysValid,
+            refillsLeft 
+        ).then((answer) => {
+            console.log(answer);
+            return finish('update is WIP ', true);
+        })
+        .catch((error) => {
+            return finish("/api/v1/prescriptions/edit: error: " + error.toString(), false);
+        });
+    } else { // cancel prescription from dummy data
+        return finish("edit tmp: dummy data not changed", true);
+    }
 });
 
 /*

--- a/WebPhapp/backend/server.js
+++ b/WebPhapp/backend/server.js
@@ -578,14 +578,9 @@ app.get('/api/v1/dispensers/redeem/:prescriptionID', (req, res) => {
     }
 
     if(conn.Blockchain) {
-        block_helper.getChainLength()
-        .then((chainLength) => {
-            // check length of blockchain to see if prescriptionID is valid (prescriptions are indexed by ID)
-            if(prescriptionID >= chainLength) {
-                return finish('/api/v1/dispensers/redeem: given prescriptionID is invalid.', false);
-            }
-
-            // now we can redeem the prescription
+        // check length of blockchain to see if prescriptionID is valid (prescriptions are indexed by ID)
+        block_helper.verifyChainIndex(prescriptionID)
+        .then((_) => {
             block_helper.redeem(prescriptionID, fillDate)
             .then((_) => {
                 return finish('/api/v1/dispensers/redeem: redeemed prescription with ID ' + prescriptionID.toString(), true);
@@ -602,7 +597,7 @@ app.get('/api/v1/dispensers/redeem/:prescriptionID', (req, res) => {
             __dirname + '/dummy_data/prescriptions.json').prescriptions;
 
         var prescription = prescriptions.find( function(elem) {
-            return elem.prescriptionID === changedPrescription.prescriptionID;
+            return elem.prescriptionID === prescriptionID;
         });
         return finish('/api/v1/dispensers/redeem: tmp: dummy data not changed', true);
     }

--- a/WebPhapp/backend/server.js
+++ b/WebPhapp/backend/server.js
@@ -57,6 +57,9 @@ app.get('/api/v1/list', (req,res) => {
 // given prescription ID.
 // example: http://localhost:5000/api/v1/prescriptions/cancel/2
 app.get('/api/v1/prescriptions/cancel/:prescriptionID', (req,res) => {
+    var prescriptionID = parseInt(req.params.prescriptionID);
+    var date = new Date().getTime();
+
     //TODO Check for auth to do this.
     //TODO Check for valid prescriptionID
 
@@ -67,6 +70,17 @@ app.get('/api/v1/prescriptions/cancel/:prescriptionID', (req,res) => {
         return;
     }
 
+    if(conn.Blockchain){
+        block_helper.cancel(prescriptionID, date)
+        .then((answer) => {
+            console.log(answer);
+        })
+        .catch((error) => {
+            finish("/api/v1/prescriptions: error: " + error.toString(), false);
+        });
+    } else {
+        null;
+    }
     //TODO Cancel the prescription on the blockchain
     return finish("TODO: build prescription cancel to blockchain", true);
 });

--- a/WebPhapp/backend/server.js
+++ b/WebPhapp/backend/server.js
@@ -53,7 +53,8 @@ function convertDatesToString(prescription){
 
 // An api endpoint that cancels the prescription associated with a
 // given prescription ID.
-// example: http://localhost:5000/api/v1/prescriptions/cancel/2
+// Example: 
+//      >>> curl "http://localhost:5000/api/v1/prescriptions/cancel/0"
 app.get('/api/v1/prescriptions/cancel/:prescriptionID', (req,res) => {
     var prescriptionID = parseInt(req.params.prescriptionID);
     var date = new Date().getTime();
@@ -72,15 +73,14 @@ app.get('/api/v1/prescriptions/cancel/:prescriptionID', (req,res) => {
         block_helper.cancel(prescriptionID, date)
         .then((answer) => {
             console.log(answer);
+            finish('cancel is WIP ', true);
         })
         .catch((error) => {
-            finish("/api/v1/prescriptions: error: " + error.toString(), false);
+            finish("/api/v1/prescriptions/cancel: error: " + error.toString(), false);
         });
-    } else {
-        null;
+    } else { // cancel prescription from dummy data
+        finish("cancel tmp: dummy data not changed", true);
     }
-    //TODO Cancel the prescription on the blockchain
-    return finish("TODO: build prescription cancel to blockchain", true);
 });
 
 /*

--- a/WebPhapp/backend/server.js
+++ b/WebPhapp/backend/server.js
@@ -558,7 +558,7 @@ app.get('/api/v1/patients/:patientID', (req,res) => {
 
 /*
 About:
-    An api endpoint that returns all related prescriptions for a given dispenserID.
+    An api endpoint that redeems a prescription at a specific prescriptionID.
 Examples:
     Directly in terminal:
         >>> curl "http://localhost:5000/api/v1/dispensers/redeem/1"


### PR DESCRIPTION
Added cancellation, prescription redeeming and prescription updating to blockchain and backend.

Included an index checker, for valid indeces on the blockchain, currently not hooked into any backend functions, but available for future extension.

Truffle tests for redeeming, cancellation, and updating.
Blockchain script for cancellation, and update included. 

Backend functionality for cancellation tested, updating still needs to be tested through the backend.
I did not see a backend route for redeeming, but it could be that the backend was intended to implement redeeming through update, in which case the redeem function is redundant.

This is a large update, so review carefully before merge, thanks.